### PR TITLE
registry/config shouldn't be deployed 

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,9 +479,9 @@ You can easily scale out micro service apps in Azure Spring Cloud:
 az spring-cloud app scale --name gateway --instance-count 4
 ```
 
-## Notes
+## Registry and Config Service Notes
 
-Registry and Config apps shouldn't be deployed as Piggymetrics will not work properly if you deploy your own Config and Eureka Discovery servers.
+Registry and Config apps shouldn't be deployed as Piggymetrics will not work properly if you deploy those Config and Eureka Discovery servers.
 There will be serviceId conflict because Azure provides own Config and Registry services.
 see 
 https://docs.microsoft.com/en-us/azure/spring-cloud/spring-cloud-service-registration

--- a/README.md
+++ b/README.md
@@ -479,14 +479,12 @@ You can easily scale out micro service apps in Azure Spring Cloud:
 az spring-cloud app scale --name gateway --instance-count 4
 ```
 
-## Registry and Config Service Notes
+## Spring Cloud Service Registry and Spring Cloud Config Server Notes
 
-Registry and Config apps shouldn't be deployed as Piggymetrics will not work properly if you deploy those Config and Eureka Discovery servers.
-There will be serviceId conflict because Azure provides own Config and Registry services.
-see 
-https://docs.microsoft.com/en-us/azure/spring-cloud/spring-cloud-service-registration
-To use own Eurek Discovery server (including Eureka UI) you should deploy Dockerised app to Azure VM see
-https://github.com/sqshq/piggymetrics
+Service Registry and Config Server apps should not be deployed as Piggymetrics will not work properly if you deploy those apps. Because, there will be serviceId conflict as Azure provides its own fully managed [Spring Cloud Service Registry and Spring Cloud Config Server services](https://docs.microsoft.com/en-us/azure/spring-cloud/spring-cloud-service-registration). 
+
+To use own Eurek Discovery server (including Eureka UI) you should deploy Dockerised app to Azure see
+[https://github.com/azure-samples/java-on-aks](https://github.com/azure-samples/java-on-aks).
 
 ## Congratulations
 

--- a/README.md
+++ b/README.md
@@ -479,6 +479,15 @@ You can easily scale out micro service apps in Azure Spring Cloud:
 az spring-cloud app scale --name gateway --instance-count 4
 ```
 
+## Notes
+
+Registry and Config apps shouldn't be deployed as Piggymetrics will not work properly if you deploy your own Config and Eureka Discovery servers.
+There will be serviceId conflict because Azure provides own Config and Registry services.
+see 
+https://docs.microsoft.com/en-us/azure/spring-cloud/spring-cloud-service-registration
+To use own Eurek Discovery server (including Eureka UI) you should deploy Dockerised app to Azure VM see
+https://github.com/sqshq/piggymetrics
+
 ## Congratulations
 
 Congratulations!! 


### PR DESCRIPTION
it's a bit confusing to maintain registry
https://github.com/Azure-Samples/azure-spring-cloud/tree/master/.prep/piggymetrics/registry/src/main/resources

I haven't managed to configure/use it properly with azure spring cloud might be good to explicitly mention about it... It could save others a bit of time