### PR TITLE
Updating Azure Spring Cloud Client and Spring Boot deps

### DIFF
--- a/.prep/piggymetrics/pom.xml
+++ b/.prep/piggymetrics/pom.xml
@@ -20,7 +20,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring-cloud.version>Greenwich.SR3</spring-cloud.version>
+		<spring-cloud.version>Greenwich.SR4</spring-cloud.version>
 		<java.version>1.8</java.version>
 	</properties>
 
@@ -65,18 +65,9 @@
 				<dependency>
 					<groupId>com.microsoft.azure</groupId>
 					<artifactId>spring-cloud-starter-azure-spring-cloud-client</artifactId>
-					<version>2.1.0-SNAPSHOT</version>
+					<version>2.1.1</version>
 				</dependency>
 			</dependencies>
-			<repositories>
-				<repository>
-					<id>nexus-snapshots</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</repository>
-			</repositories>
 		</profile>
 
 	</profiles>


### PR DESCRIPTION
Changing POM to use 2.1.1 release of Azure Spring Cloud Client instead of a snapshot. Also updating Spring Boot version from `Greenwich.SR3` to `Greenwich.SR4`